### PR TITLE
Update Markets.sol

### DIFF
--- a/contracts/Markets.sol
+++ b/contracts/Markets.sol
@@ -131,10 +131,12 @@ contract Market is IWeb3BetsMarketV1 {
         uint256 vigPercentage = web3Bets.getVigPercentage();
         uint marketBalance = address(this).balance;
         // Get total stake and transfer to market
-        uint256 vigShare = (marketBalance * vigPercentage) / 100;
-
+        
         IWeb3BetsPoolsV1 pool = IWeb3BetsPoolsV1(_poolAddress);
         uint256 poolTotalStake = pool.getTotalStake();
+        
+        uint256 vigShare = ((marketBalance - poolTotalStake) * vigPercentage) / 100;
+
          marketBalance = marketBalance - vigShare;
 
  


### PR DESCRIPTION
Check the proposed correction for vigShare calculation.

the vig is not deducted from the winning pool's stake.

Therefore, the winning pool's stake should be deducted from the market balance before multiplying by the vig percentage.

Before you merge, please confirm that this change will not affect any other thing in the codes.